### PR TITLE
Have UMA Object inherit UI layer of parent

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMADefaultMeshCombiner.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMADefaultMeshCombiner.cs
@@ -90,6 +90,7 @@ namespace UMA
 			newSMRGO.transform.localPosition = Vector3.zero;
 			newSMRGO.transform.localRotation = Quaternion.Euler(0, 0, 0f);
 			newSMRGO.transform.localScale = Vector3.one;
+			newSMRGO.gameObject.layer = umaData.gameObject.layer;
 
 			var newRenderer = newSMRGO.AddComponent<SkinnedMeshRenderer>();
 			newRenderer.enabled = false;


### PR DESCRIPTION
UI layer was being set to default.  Some tools use UI layer for camera culling.  Updated to inherit parent object's UI layer.